### PR TITLE
Use max_completion_tokens and drop unsupported temperatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Upload a PDF and provide your OpenAI API key in the sidebar. Once processing com
 
 ## Usage
 
-Optional CLI flags such as `--mode`, `--model`, and `--temperature` can be supplied as needed.
+Optional CLI flags such as `--mode`, `--model`, and `--temperature` can be supplied as needed. Note that some OpenAI models only support the default temperature and will ignore or reject other values.
 
 ### Important Notes
 

--- a/llm_handler.py
+++ b/llm_handler.py
@@ -23,7 +23,7 @@ def summarize_groups(
     groups: List[List[int]],
     *,
     model: str = "gpt-5-mini-2025-08-07",
-    temperature: float = 0.3,
+    temperature: float | None = None,
 ) -> Dict[int, str]:
     """Generate summaries for pages of a PDF grouped by context.
 
@@ -40,9 +40,10 @@ def summarize_groups(
     model : str, optional
         OpenAI model name to use for summarisation, by default
         ``"gpt-5-mini-2025-08-07"``.
-    temperature : float, optional
-        Sampling temperature for the model. Lower values make the
-        output more deterministic, by default ``0.3``.
+    temperature : float | None, optional
+        Sampling temperature for the model. If ``None`` the model's
+        default temperature is used. Some models only support the
+        default temperature.
 
     Returns
     -------
@@ -101,11 +102,10 @@ def summarize_groups(
                     }
                 )
             try:
-                response = client.chat.completions.create(
-                    model=model,
-                    messages=messages,
-                    temperature=temperature,
-                )
+                params = {"model": model, "messages": messages}
+                if temperature is not None:
+                    params["temperature"] = temperature
+                response = client.chat.completions.create(**params)
                 summary = response.choices[0].message.content.strip()
             except Exception as exc:
                 logging.error(
@@ -123,8 +123,8 @@ def explain_section(
     *,
     model: str = "gpt-5-mini-2025-08-07",
     language: str = "ko",
-    max_tokens: int = 2200,
-    temperature: float = 0.2,
+    max_completion_tokens: int = 2200,
+    temperature: float | None = None,
 ) -> str:
     """Return detailed explanations for slides within a section."""
 
@@ -180,12 +180,14 @@ def explain_section(
     ]
 
     def _call() -> str:
-        resp = client.chat.completions.create(
-            model=model,
-            messages=messages,
-            max_tokens=max_tokens,
-            temperature=temperature,
-        )
+        params = {
+            "model": model,
+            "messages": messages,
+            "max_completion_tokens": max_completion_tokens,
+        }
+        if temperature is not None:
+            params["temperature"] = temperature
+        resp = client.chat.completions.create(**params)
         return resp.choices[0].message.content.strip()
 
     import re

--- a/main.py
+++ b/main.py
@@ -22,8 +22,14 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--lang", default="ko")
     parser.add_argument("--section-size-limit", type=int, default=8)
     parser.add_argument("--model", default="gpt-5-mini")
-    parser.add_argument("--temperature", type=float, default=0.2)
-    parser.add_argument("--max-tokens", type=int, default=2200)
+    parser.add_argument("--temperature", type=float, default=None)
+    parser.add_argument(
+        "--max-completion-tokens",
+        "--max-tokens",
+        dest="max_completion_tokens",
+        type=int,
+        default=2200,
+    )
 
     parser.add_argument("--semantic-weight", type=float, default=0.4)
     parser.add_argument("--visual-weight", type=float, default=0.2)
@@ -103,7 +109,7 @@ def main(argv: List[str] | None = None) -> int:
                     section.title,
                     model=args.model,
                     language=args.lang,
-                    max_tokens=args.max_tokens,
+                    max_completion_tokens=args.max_completion_tokens,
                     temperature=args.temperature,
                 )
                 import re

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -81,8 +81,7 @@ if generate and uploaded_pdf and api_key:
                     section.title,
                     model="gpt-5-mini",
                     language="ko",
-                    max_tokens=2200,
-                    temperature=0.2,
+                    max_completion_tokens=2200,
                 )
                 pattern = re.compile(r"페이지 (\d+):\n?(.*?)\n(?=페이지 \d+:|\Z)", re.S)
                 for match in pattern.finditer(explanation + "\n"):
@@ -98,7 +97,7 @@ if generate and uploaded_pdf and api_key:
             texts=texts,
             groups=groups,
             model="gpt-5-mini",
-            temperature=0.2,
+            # Use the model's default temperature
         )
         slides = [(i + 1, summaries[i]) for i in sorted(summaries.keys())]
         section_outputs.append(("Summary", slides))


### PR DESCRIPTION
## Summary
- replace deprecated `max_tokens` with `max_completion_tokens` in OpenAI helper and callers
- avoid sending a `temperature` argument unless explicitly provided to handle GPT-5 models
- expose `--temperature` CLI flag as optional and remove Streamlit's hard‑coded temperature

## Testing
- `python -m py_compile llm_handler.py streamlit_app.py main.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a343c843808321b07731a1d91dfd7a