### PR TITLE
fix: handle page parsing with flexible regex

### DIFF
--- a/llm_handler.py
+++ b/llm_handler.py
@@ -230,7 +230,7 @@ def explain_section(
     for _ in range(1):
         ok = True
         for page, _ in items:
-            if not re.search(rf"^페이지 {page}:", out, re.MULTILINE):
+            if not re.search(rf"^\s*페이지\s*{page}\s*:", out, re.MULTILINE):
                 ok = False
                 break
         if ok:

--- a/main.py
+++ b/main.py
@@ -115,8 +115,11 @@ def main(argv: List[str] | None = None) -> int:
                 )
                 import re
 
-                pattern = re.compile(r"페이지 (\d+):\n?(.*?)\n(?=페이지 \d+:|\Z)", re.S)
-                for match in pattern.finditer(explanation + "\n"):
+                pattern = re.compile(
+                    r"페이지\s*(\d+)\s*:\s*(.*?)(?=\n\s*페이지\s*\d+\s*:|\Z)",
+                    re.S,
+                )
+                for match in pattern.finditer(explanation.strip() + "\n"):
                     num = int(match.group(1))
                     txt = match.group(2).strip()
                     slides_accum.append((num, txt))


### PR DESCRIPTION
## Summary
- improve validation to accept page labels with leading spaces
- parse LLM explanations using whitespace-tolerant regex so later pages are captured

## Testing
- `python -m py_compile llm_handler.py main.py`
- `pytest >/tmp/pytest.log || true`

------
https://chatgpt.com/codex/tasks/task_e_68a441d5a040832197ac2a146f34d672