### PR TITLE
fix: use shared page parser

### DIFF
--- a/main.py
+++ b/main.py
@@ -52,6 +52,7 @@ def _load_openai_key(args: argparse.Namespace) -> str:
     return key
 
 
+
 def main(argv: List[str] | None = None) -> int:
     args = parse_args(argv)
     api_key = _load_openai_key(args)
@@ -113,12 +114,7 @@ def main(argv: List[str] | None = None) -> int:
                     max_completion_tokens=args.max_completion_tokens,
                     temperature=args.temperature,
                 )
-                import re
-
-                pattern = re.compile(r"페이지 (\d+):\n?(.*?)\n(?=페이지 \d+:|\Z)", re.S)
-                for match in pattern.finditer(explanation + "\n"):
-                    num = int(match.group(1))
-                    txt = match.group(2).strip()
+                for num, txt in llm_handler.parse_page_explanations(explanation):
                     slides_accum.append((num, txt))
             section_outputs.append((section.title, slides_accum))
     else:


### PR DESCRIPTION
## Summary
- add `parse_page_explanations` helper to `llm_handler` for consistent slide parsing
- reuse shared parser in CLI and Streamlit to avoid syntax errors

## Testing
- `python -m py_compile llm_handler.py main.py streamlit_app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68a441d5a040832197ac2a146f34d672