### PR TITLE
feat: auto chunk sections by text length

### DIFF
--- a/main.py
+++ b/main.py
@@ -21,7 +21,6 @@ def parse_args(argv: List[str] | None = None) -> argparse.Namespace:
 
     parser.add_argument("--mode", choices=["explain", "summarize"], default="explain")
     parser.add_argument("--lang", default="ko")
-    parser.add_argument("--section-size-limit", type=int, default=8)
     parser.add_argument("--model", default="gpt-5-mini")
     parser.add_argument("--temperature", type=float, default=None)
 
@@ -94,10 +93,8 @@ def main(argv: List[str] | None = None) -> int:
     if args.mode == "explain":
         for section in sections:
             pages = section.pages
-            chunked = [
-                pages[i : i + args.section_size_limit]
-                for i in range(0, len(pages), args.section_size_limit)
-            ]
+            chunked = pdf_processor.chunk_pages_by_text_length(pages, page_metas)
+            logging.info("Chunk sizes: %s", [len(c) for c in chunked])
             slides_accum: List[Tuple[int, str]] = []
             for chunk in chunked:
                 items: List[Tuple[int, str]] = []

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -42,8 +42,6 @@ if temperature_opt.strip():
     except ValueError:
         st.warning("Temperature must be a number. Using model default.")
 
-section_size_limit = st.number_input("Section chunk size", 1, 20, 8, 1)
-
 DEBUG_LOG = ROOT / "debug_output.txt"
 
 # Initialize session state
@@ -108,11 +106,11 @@ if generate:
                 if mode == "explain":
                     for section in sections:
                         pages = section.pages
-                        # chunk pages to stay under token limits
-                        chunks = [
-                            pages[i : i + int(section_size_limit)]
-                            for i in range(0, len(pages), int(section_size_limit))
-                        ]
+                        # chunk pages automatically based on text length
+                        chunks = pdf_processor.chunk_pages_by_text_length(
+                            pages, page_metas
+                        )
+                        _write_debug(f"Chunk sizes: {[len(c) for c in chunks]}")
                         slides_accum: List[Tuple[int, str]] = []
 
                         for chunk in chunks:


### PR DESCRIPTION
## Summary
- remove manual section size configuration and compute chunk sizes automatically
- add `chunk_pages_by_text_length` helper for character-based page batching
- update streamlit and CLI workflows to use new chunking helper

## Testing
- `python -m py_compile main.py pdf_processor.py streamlit_app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b646bf241883219f455e52d0967520